### PR TITLE
* actually use FSTree to minimize output

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var arrayEqual = require('array-equal');
 var Plugin = require('broccoli-plugin');
 var symlinkOrCopy = require('symlink-or-copy');
 var debug = require('debug');
-var FSTree = require('fs-tree');
+var FSTree = require('./fs-tree');
+var rimraf = require('rimraf');
 
 function makeDictionary() {
   var cache = Object.create(null);
@@ -26,11 +27,11 @@ function Funnel(inputNode, options) {
 
   Plugin.call(this, [inputNode]);
 
+  this._persistentOutput = true;
+
   this._includeFileCache = makeDictionary();
   this._destinationPathCache = makeDictionary();
-  this._fsTree = new FSTree({
-    ignore: ['update'];
-  });
+  this._fsTree = new FSTree();
 
   var keys = Object.keys(options || {});
   for (var i = 0, l = keys.length; i < l; i++) {
@@ -39,6 +40,7 @@ function Funnel(inputNode, options) {
   }
 
   this.destDir = this.destDir || '/';
+  this.count = 0;
 
   if (this.files && typeof this.files === 'function') {
     // Save dynamic files func as a different variable and let the rest of the code
@@ -133,7 +135,7 @@ Funnel.prototype.build = function() {
   if (this.shouldLinkRoots()) {
     linkedRoots = true;
     if (fs.existsSync(inputPath)) {
-      fs.rmdirSync(this.outputPath);
+      rimraf.sync(this.outputPath);
       this._copy(inputPath, this.destPath);
     } else if (this.allowEmpty) {
       mkdirp.sync(this.destPath);
@@ -163,9 +165,11 @@ Funnel.prototype.processFilters = function(inputPath) {
     }
   }
 
-  var destRelativePath, fullInputPath, fullOutputPath, filteredFiles;
+  var destRelativePath, fullInputPath, fullOutputPath;
 
-  filteredFiles = files.filter(this.includeFile, this);
+  var nextTree = new FSTree({
+    files: files.filter(this.includeFile, this)
+  });
 
   // [
   //  ["rm", "./lib/foo.js"],
@@ -173,18 +177,38 @@ Funnel.prototype.processFilters = function(inputPath) {
   //  ["create", "./lib/qq.js"],
   //  ["create", "./lib/shazam.js"],
   // ]
-  var patch = this._fsTree.calculatePatch(filteredFiles);
-  // TODO: do work and then update this._fsTree( files )
+  var patch = this._fsTree.calculatePatch(nextTree);
+  this._fsTree = nextTree;
+  var removes = patch.filter(function(entry) { return entry[0] === 'rm'; }).map(byPath);
+  var adds    = patch.filter(function(entry) { return entry[0] === 'create'; }).map(byPath);
 
-  var count = filteredFiles.length;
+  function byPath(operation) {
+    return operation[1];
+  }
 
-  filteredFiles.forEach(function(relativePath) {
+
+  function prependPath(outputPath) {
+    return function(path) {
+      return outputPath + '/' + path;
+    };
+  }
+
+  removes.map(prependPath(this.outputPath)).forEach(function(path) {
+    rimraf.sync(path);
+  });
+
+  adds.map(function(relativePath) {
     fullInputPath    = path.join(inputPath, relativePath);
     destRelativePath = this.lookupDestinationPath(relativePath);
     fullOutputPath   = path.join(this.destPath, destRelativePath);
 
     this.processFile(fullInputPath, fullOutputPath, relativePath);
   }, this);
+
+
+  // TODO: do work and then update this._fsTree( files )
+
+  var count = nextTree.size;
 
   this._debug('processFilters %o', {
     in: new Date() - this._buildStart + 'ms',

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "array-equal": "^1.0.0",
     "broccoli-plugin": "^1.0.0",
     "debug": "^2.2.0",
+    "fast-ordered-set": "^1.0.0",
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",
+    "rimraf": "^2.4.3",
     "symlink-or-copy": "^1.0.0",
     "walk-sync-matcher": "^0.2.2"
   },

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -76,8 +76,8 @@ describe('FSTree', function() {
           expect(fsTree.calculatePatch([
             'bar/two.js'
           ])).to.deep.equal([
-            ['rm', 'foo'],
             ['rm', 'bar/one.js'],
+            ['rm', 'foo']
           ]);
         });
       });
@@ -90,6 +90,27 @@ describe('FSTree', function() {
             ['rm', 'foo'],
             ['rm', 'bar'],
             ['create', 'bar/three.js'],
+          ]);
+        });
+      });
+    });
+
+    context('from a deep non-empty tree', function() {
+      beforeEach( function() {
+        fsTree = new FSTree({
+          files: [
+            'bar/quz/baz.js',
+            'foo.js',
+          ],
+        });
+      });
+
+      context('to an empty tree', function() {
+        it('returns n rm operations', function() {
+          expect(fsTree.calculatePatch([])).to.deep.equal([
+            ['rm', 'bar/quz'],
+            ['rm', 'bar'],
+            ['rm', 'foo.js'],
           ]);
         });
       });


### PR DESCRIPTION
- enable persistentOutput
- switch to fast-ordered-set
- don’t try and delete root
- issue more ideal commands
  `[bar/baz/quz.js] -> []  becomes: “rm bar/baz” “rm bar”`

needs:
- [x] split `rm` into  `rmdir` and `unlink`
- [x] confirm nested structure, with a mixture of files and folders reduce correctly.
- [ ] extract FSTree lib entirely.

![piratebroccoli](https://cloud.githubusercontent.com/assets/1377/9826712/2220da8a-5891-11e5-869e-655d68a096a8.png)
